### PR TITLE
125-uv-open-left-panel-by-default

### DIFF
--- a/config/uv/uv-config.json
+++ b/config/uv/uv-config.json
@@ -44,7 +44,7 @@
         "panelAnimationDuration": 250,
         "panelCollapsedWidth": 30,
         "panelExpandedWidth": 255,
-        "panelOpen": false,
+        "panelOpen": true,
         "tabOrder": "",
         "thumbsEnabled": true,
         "thumbsExtraHeight": 8,


### PR DESCRIPTION
# Summary 
ref: https://gitlab.com/notch8/louisville-hyku/-/issues/125#note_1085366072

- set left content panel to open by default when looking at works with multiple filesets

you may need to run yarn and refresh browser's cache.

# Expected Behavior

- user should see the left content panel slide out by default instead of needing to click on it to make it appear

# Notes

When `_universel_viewer.html.erb` was brought back in f13b1e38, the Universal Viewer now reads from the `uv-config.json` from this project.  The `panelOpen` setting was set to `false` and now has been changed.  There are some other settings in there that are opposite to what I've seen as a default option from this sandbox UV version: http://wellcometesters.azurewebsites.net/ such as `"defaultToTreeEnabled": false,` and `"expandFullEnabled": true,`.  I flipped them to test but saw no change, at least with the test data I had so I did not alter those values.