### PR TITLE
working on a prod ready docker-compose file for louisvill

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -35,7 +35,7 @@ volumes:
     type: "cifs"
     device: "//136.165.112.51/Groups/Digital/HykuImports"
     o: "addr=136.165.112.51,ro,cached"
-    o: "uid=0,username=hyku,password=iuse4rchbtw!,file_mode=0777,dir_mode=0777"
+    o: "uid=0,username=${IMPORT_USER},password=${IMPORT_PASSWORD},file_mode=0777,dir_mode=0777"
 
 networks:
   internal:


### PR DESCRIPTION
This docker-compose.production.yml file uses postgres to back the fcrepo instead of the flat file data store. this is much less likely to become corrupted as work gets put in to the system.

You can access it with `docker compose -f docker-compose.production.yml up web` or similar commands.

I additionally took out chrome from this file, since that is only for running Selenium tests and takes up a bunch of resources. Also I'd recommend considering the following additional changes:

- marking services as `restart: always`
- removing the build: blocks and only using pulled images on the prod server (for faster deploy times and reproducability)